### PR TITLE
remove storageclass name

### DIFF
--- a/k8s/mysql.yml
+++ b/k8s/mysql.yml
@@ -5,7 +5,6 @@ metadata:                          # Claim name and labels
   labels:
     app: polling-app
 spec:                              # Access mode and resource limits
-  storageClassName: standard       # Request a certain storage class
   accessModes:
     - ReadWriteOnce                # ReadWriteOnce means the volume can be mounted as read-write by a single Node
   resources:


### PR DESCRIPTION
The default name of the storageclass is not consistent across k8s installations (in my eks cluster it was `gp2`, not `standard`).